### PR TITLE
Converted storeDir to publishDir for processing data.

### DIFF
--- a/modules/genelab.nf
+++ b/modules/genelab.nf
@@ -4,7 +4,7 @@
 process RNASEQ_RUNSHEET_FROM_GLDS {
   conda "${baseDir}/envs/AST.yml"
   tag "${ glds_accession }"
-  storeDir "${ params.gldsAccession }/Metadata"
+  publishDir "${ params.gldsAccession }/Metadata"
 
   input:
     val(glds_accession)
@@ -25,7 +25,7 @@ process RNASEQ_RUNSHEET_FROM_GLDS {
 
 process STAGE_RAW_READS {
   tag "${ meta.id }"
-  storeDir "${ params.gldsAccession }/${ meta.raw_read_root_dir }"
+  publishDir "${ params.gldsAccession }/${ meta.raw_read_root_dir }"
 
   input:
     tuple val(meta), path("?.gz")
@@ -49,7 +49,7 @@ process STAGE_RAW_READS {
 
 process GENERATE_METASHEET {
   tag "${ params.gldsAccession }"
-  storeDir "${ params.gldsAccession }/Metadata"
+  publishDir "${ params.gldsAccession }/Metadata"
 
   input:
     path("isa.zip")

--- a/modules/genome.nf
+++ b/modules/genome.nf
@@ -109,7 +109,7 @@ process BUILD_RSEM {
 process COUNT_ALIGNED {
   conda "${baseDir}/envs/rsem.yml"
   tag "Sample: ${ meta.id }"
-  storeDir "${ params.gldsAccession }/${ meta.RSEM_Counts_dir }"
+  publishDir "${ params.gldsAccession }/${ meta.RSEM_Counts_dir }"
 
   input:
     tuple val(meta), path(transcriptomeMapping), path(RSEM_REF)

--- a/modules/quality.nf
+++ b/modules/quality.nf
@@ -7,7 +7,7 @@ process RAW_FASTQC {
   conda "${baseDir}/envs/fastqc.yml"
   tag "Sample: ${ meta.id }"
   // cpus { read.size() } // BUGGED FOR SINGLE READS: number of read files to process
-  storeDir "${ params.gldsAccession }/${ meta.raw_read_fastQC }"
+  publishDir "${ params.gldsAccession }/${ meta.raw_read_fastQC }"
 
   input:
     tuple val(meta), path(reads)
@@ -26,7 +26,7 @@ process TRIMMED_FASTQC {
   conda "${baseDir}/envs/fastqc.yml"
   tag "Sample: ${ meta.id }"
   // cpus { read.size() } // BUGGED FOR SINGLE READS: number of read files to process
-  storeDir "${ params.gldsAccession }/${ meta.trimmed_read_fastQC }"
+  publishDir "${ params.gldsAccession }/${ meta.trimmed_read_fastQC }"
 
   input:
   tuple val(meta), path(reads)
@@ -45,7 +45,7 @@ process RAW_MULTIQC {
   label "fastLocal"
   tag "Dataset: ${ params.gldsAccession }"
   conda "${baseDir}/envs/multiqc.yml"
-  storeDir "${ params.gldsAccession }/00-RawData/FastQC_Reports"
+  publishDir "${ params.gldsAccession }/00-RawData/FastQC_Reports"
 
   input:
     path("fastqc/*") // any number of fastqc files


### PR DESCRIPTION
This allows the resume/cache system to take over.
This does neccessitate a dereferenced copy after finishing to prevent 
the files from being removed as they are located in the nextflow work 
(linked to the publish directories).