### PR TITLE
Added in handling for keytypes that differ from ENSEMBL.

### DIFF
--- a/bin/DEBUG_deseq2_normcounts_noERCC_DGE_vis_ISA.R
+++ b/bin/DEBUG_deseq2_normcounts_noERCC_DGE_vis_ISA.R
@@ -180,9 +180,25 @@ for (i in 1:dim(contrasts)[2]){
   rm(res_1)
 }
 
+## Determine the keytype to use for annotation database
+## Order (proceed to next if not found)
+## 'ENSEMBL' -> 'TAIR' -> Raise Error
+if ( "ENSEMBL" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "ENSEMBL"
+} else if ( "TAIR" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "TAIR"
+} else {
+  stop(
+    sprintf("Neither 'ENSEMBL' nor 'TAIR' keytypes found in %s. The following keytypes were found '%s'",
+            ann.dbi,
+            paste( keytypes( eval( parse(text = ann.dbi) ) ), collapse="' '" )
+          )
+      )
+}
+sprintf("Using '%s' keytype for %s", keytype, ann.dbi )
 
 ## Create annotation table and add gene annotation columns
-keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL
+#keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL # replaced by section above
 annot <- data.frame(rownames(output_table_1), stringsAsFactors = FALSE)
 colnames(annot)[1]<-keytype
 if ("SYMBOL" %in% columns(eval(parse(text = ann.dbi),env=.GlobalEnv))){

--- a/bin/DEBUG_deseq2_normcounts_wERCC_DGE_vis_ISA.R
+++ b/bin/DEBUG_deseq2_normcounts_wERCC_DGE_vis_ISA.R
@@ -239,9 +239,25 @@ for (i in 1:dim(contrasts)[2]){
   rm(res_1)
 }
 
+## Determine the keytype to use for annotation database
+## Order (proceed to next if not found)
+## 'ENSEMBL' -> 'TAIR' -> Raise Error
+if ( "ENSEMBL" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "ENSEMBL"
+} else if ( "TAIR" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "TAIR"
+} else {
+  stop(
+    sprintf("Neither 'ENSEMBL' nor 'TAIR' keytypes found in %s. The following keytypes were found '%s'",
+            ann.dbi,
+            paste( keytypes( eval( parse(text = ann.dbi) ) ), collapse="' '" )
+          )
+      )
+}
+sprintf("Using '%s' keytype for %s", keytype, ann.dbi )
 
 ## Create annotation table and add gene annotation columns
-keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL
+#keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL # replaced by section above
 annot <- data.frame(rownames(output_table_1), stringsAsFactors = FALSE)
 colnames(annot)[1]<-keytype
 if ("SYMBOL" %in% columns(eval(parse(text = ann.dbi),env=.GlobalEnv))){

--- a/bin/deseq2_normcounts_noERCC_DGE_vis_ISA.R
+++ b/bin/deseq2_normcounts_noERCC_DGE_vis_ISA.R
@@ -176,9 +176,25 @@ for (i in 1:dim(contrasts)[2]){
   rm(res_1)
 }
 
+## Determine the keytype to use for annotation database
+## Order (proceed to next if not found)
+## 'ENSEMBL' -> 'TAIR' -> Raise Error
+if ( "ENSEMBL" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "ENSEMBL"
+} else if ( "TAIR" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "TAIR"
+} else {
+  stop(
+    sprintf("Neither 'ENSEMBL' nor 'TAIR' keytypes found in %s. The following keytypes were found '%s'",
+            ann.dbi,
+            paste( keytypes( eval( parse(text = ann.dbi) ) ), collapse="' '" )
+          )
+      )
+}
+sprintf("Using '%s' keytype for %s", keytype, ann.dbi )
 
 ## Create annotation table and add gene annotation columns
-keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL
+#keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL # replaced by section above
 annot <- data.frame(rownames(output_table_1), stringsAsFactors = FALSE)
 colnames(annot)[1]<-keytype
 if ("SYMBOL" %in% columns(eval(parse(text = ann.dbi),env=.GlobalEnv))){

--- a/bin/deseq2_normcounts_wERCC_DGE_vis_ISA.R
+++ b/bin/deseq2_normcounts_wERCC_DGE_vis_ISA.R
@@ -235,9 +235,25 @@ for (i in 1:dim(contrasts)[2]){
   rm(res_1)
 }
 
+## Determine the keytype to use for annotation database
+## Order (proceed to next if not found)
+## 'ENSEMBL' -> 'TAIR' -> Raise Error
+if ( "ENSEMBL" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "ENSEMBL"
+} else if ( "TAIR" %in% keytypes( eval( parse(text = ann.dbi) ) ) ) {
+  keytype = "TAIR"
+} else {
+  stop(
+    sprintf("Neither 'ENSEMBL' nor 'TAIR' keytypes found in %s. The following keytypes were found '%s'",
+            ann.dbi,
+            paste( keytypes( eval( parse(text = ann.dbi) ) ), collapse="' '" )
+          )
+      )
+}
+sprintf("Using '%s' keytype for %s", keytype, ann.dbi )
 
 ## Create annotation table and add gene annotation columns
-keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL
+#keytype = "ENSEMBL" # will be different if primary annotations are not ENSEMBL # replaced by section above
 annot <- data.frame(rownames(output_table_1), stringsAsFactors = FALSE)
 colnames(annot)[1]<-keytype
 if ("SYMBOL" %in% columns(eval(parse(text = ann.dbi),env=.GlobalEnv))){


### PR DESCRIPTION
Currently supports TAIR as a fallback keytype.
Also prints custom error messages that better characterize the missing 
accepted keytype error.